### PR TITLE
worker: refactor to use less channels

### DIFF
--- a/worker/upstream_worker_test.go
+++ b/worker/upstream_worker_test.go
@@ -38,14 +38,13 @@ func TestUpstreamWorkerWithTwoURIAndSingleWorkerFirstFail(t *testing.T) {
 	callCount := 0
 	w := New(1, func(uri string) (*response.Response, error) {
 		callCount++
-		time.Sleep(10 * time.Millisecond)
 
-		return &response.Response{}, fmt.Errorf("Boom")
+		return &response.Response{}, fmt.Errorf(fmt.Sprintf("%d", callCount))
 	})
 
 	w.Do([]string{"123", "abc"})
 
-	assert.Equal(t, 1, callCount)
+	assert.Equal(t, w.err.Error(), "1")
 }
 
 func TestUpstreamWorkerWithTwoURIAndTwoWorkers(t *testing.T) {
@@ -76,10 +75,10 @@ func TestUpstreamWorkerWithTwoURIAndTwoWorkerFirstFail(t *testing.T) {
 	w := New(2, func(uri string) (*response.Response, error) {
 		callCount++
 
-		return &response.Response{}, fmt.Errorf("Boom")
+		return &response.Response{}, fmt.Errorf(fmt.Sprintf("%d", callCount))
 	})
 
 	w.Do([]string{"123", "abc"})
 
-	assert.Equal(t, 1, callCount)
+	assert.Equal(t, w.err.Error(), "1")
 }


### PR DESCRIPTION
Hey Nic, I was using this in another project and noticed that there was a goroutine leak when proxying to upstreams. I refactored the worker to get rid of a few channels and goroutines and this it should clear up the leak. The only functional difference is that before the workers would halt on the first upstream failure but now they run through all of them but still return the first error. 