### PR TITLE
Handle https upstream URLs with HTTP handler instead of gRCP handler

### DIFF
--- a/handlers/request_http.go
+++ b/handlers/request_http.go
@@ -103,7 +103,7 @@ func (rq *Request) Handle(rw http.ResponseWriter, r *http.Request) {
 	var upstreamError error
 	if len(rq.upstreamURIs) > 0 {
 		wp := worker.New(rq.workerCount, func(uri string) (*response.Response, error) {
-			if strings.HasPrefix(uri, "http://") {
+			if strings.HasPrefix(uri, "http://") || strings.HasPrefix(uri, "https://") {
 				return workerHTTP(hq.Span.Context(), uri, rq.defaultClient, r, rq.log)
 			}
 


### PR DESCRIPTION
When trying to use an HTTPS upstream URI, this currently does not work as the endpoint is assumed to be of type gRCP. This changes the behaviour, so that HTTPS endpoints can be used.