### PR TITLE
Add API to configure fake-service

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -44,6 +44,12 @@ func NewInjector(l hclog.Logger, errorPercentage float64, errorCode int, errorTy
 	}
 }
 
+// SetErrorPercentage sets the error rate for the injector
+// must be a floating point number  between 0 and 1
+func (e *Injector) SetErrorPercentage(rate float64) {
+	e.errorPercentage = rate
+}
+
 // Do returns an error
 func (e *Injector) Do() *Response {
 	e.requestCount++ // increment the request count

--- a/handlers/config.go
+++ b/handlers/config.go
@@ -1,0 +1,67 @@
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/nicholasjackson/fake-service/errors"
+	"github.com/nicholasjackson/fake-service/logging"
+)
+
+type Config struct {
+	logger        *logging.Logger
+	errorInjector *errors.Injector
+	healthHandler *Health
+}
+
+// NewHealth creates a new health handler
+func NewConfig(logger *logging.Logger, ej *errors.Injector, hh *Health) *Config {
+	return &Config{
+		logger,
+		ej,
+		hh,
+	}
+}
+
+// Handle the request
+func (c *Config) Handle(rw http.ResponseWriter, r *http.Request) {
+	c.logger.Log().Info("Config called", "path", r.URL.Path)
+
+	// get the parameters from the path
+	parts := strings.Split(r.URL.Path, "/")
+	if len(parts) < 4 {
+		http.Error(rw, "Config endpoint expects /config/parameter/value", http.StatusBadRequest)
+		return
+	}
+
+	c.logger.Log().Info("Set config", "parameter", parts[2], "value", parts[3])
+
+	switch parts[2] {
+	case "error_rate":
+		rate, err := strconv.ParseFloat(parts[3], 64)
+		if err != nil {
+			c.logger.Log().Error("Config endpoint error_rate expects a floating point value between 0 and 1", "data", parts, "error", err)
+
+			http.Error(rw, "Config endpoint error_rate expects a floating point value between 0 and 1", http.StatusBadRequest)
+			return
+		}
+
+		c.errorInjector.SetErrorPercentage(rate)
+	case "health_check_response_code":
+		code, err := strconv.ParseInt(parts[3], 10, 64)
+		if err != nil {
+			c.logger.Log().Error("Config endpoint health_check_response_code expects an int value representing an HTTP status code", "data", parts, "error", err)
+
+			http.Error(rw, "Config endpoint health_check_response_code expects an int value representing an HTTP status code", http.StatusBadRequest)
+			return
+		}
+
+		c.healthHandler.SetStatusCode(int(code))
+	default:
+		http.Error(rw, "Invalid parameter", http.StatusBadRequest)
+		return
+	}
+
+	rw.WriteHeader(http.StatusOK)
+}

--- a/handlers/health_http.go
+++ b/handlers/health_http.go
@@ -31,3 +31,7 @@ func (h *Health) Handle(rw http.ResponseWriter, r *http.Request) {
 	rw.WriteHeader(h.statusCode)
 	fmt.Fprint(rw, "OK")
 }
+
+func (h *Health) SetStatusCode(code int) {
+	h.statusCode = code
+}

--- a/main.go
+++ b/main.go
@@ -276,9 +276,10 @@ func main() {
 		*readyRootPathWaitTillReady,
 		rh,
 	)
+	cq := handlers.NewConfig(logger, errorInjector, hh)
 
 	grpcServer := createGRPCServer(logger, requestDuration, errorInjector, generator, grpcClients, defaultClient, requestGenerator, *readyRootPathWaitTillReady, rh)
-	httpServer := createHTTPServer(hh, rh, rq, logger)
+	httpServer := createHTTPServer(hh, rh, rq, cq, logger)
 
 	// start the http/s server
 	go func() {
@@ -344,6 +345,7 @@ func createHTTPServer(
 	hh *handlers.Health,
 	rh *handlers.Ready,
 	rq http.Handler,
+	con *handlers.Config,
 	logger *logging.Logger,
 ) *http.Server {
 	mux := http.NewServeMux()
@@ -355,6 +357,9 @@ func createHTTPServer(
 	// Add the generic health and ready handlers
 	mux.HandleFunc("/health", hh.Handle)
 	mux.HandleFunc("/ready", rh.Handle)
+
+	// Add the config handler that allows modification of config values dynamically
+	mux.HandleFunc("/config/", con.Handle)
 
 	// uncomment to enable pprof
 	//mux.HandleFunc("/debug/pprof/", pprof.Index)


### PR DESCRIPTION
Add new api endpoints to enable some settings of the fake-service to be dynamically configured.

```shell
/config/error_rate/[float]
/config/health_check_response_code/[int]
```